### PR TITLE
(For Aaron) Fix Error coming from Client Class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: ruby
-script: "bundle exec rake spec"
+before_install:
+  - "gem install bundler"
+  - "bundle -v"
+install:
+  - bundle install
+script:
+  - bundle exec rake spec
 rvm:
   - 1.9.3
   - 2.0.0
-env:
-  # None for now
-gemfile:
-  - Gemfile
-services:
-  # None for now
-notifications:
-  # None for now
+  - 2.1.0
+  - 2.2.0
+  - 2.3.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    sift-partner (0.0.2)
-      httparty (>= 0.13.1)
-      multi_json (>= 1.0)
-      sift (>= 1.1.6.2)
+    sift-partner (0.0.3)
+      httparty (~> 0.13.1)
+      multi_json (~> 1.0)
+      sift (~> 1.1.7)
 
 GEM
   remote: http://rubygems.org/
@@ -13,27 +13,23 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
-    httparty (0.13.3)
+    httparty (0.13.7)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
-    json (1.8.1)
-    multi_json (1.10.1)
+    json (1.8.3)
+    multi_json (1.12.1)
     multi_xml (0.5.5)
-    rake (10.3.2)
-    rspec (3.1.0)
-      rspec-core (~> 3.1.0)
-      rspec-expectations (~> 3.1.0)
-      rspec-mocks (~> 3.1.0)
-    rspec-core (3.1.4)
-      rspec-support (~> 3.1.0)
-    rspec-expectations (3.1.1)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.1.0)
-    rspec-mocks (3.1.1)
-      rspec-support (~> 3.1.0)
-    rspec-support (3.1.0)
-    safe_yaml (1.0.3)
-    sift (1.1.6.2)
+    rake (11.1.2)
+    rspec (2.99.0)
+      rspec-core (~> 2.99.0)
+      rspec-expectations (~> 2.99.0)
+      rspec-mocks (~> 2.99.0)
+    rspec-core (2.99.2)
+    rspec-expectations (2.99.2)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.99.4)
+    safe_yaml (1.0.4)
+    sift (1.1.7.3)
       httparty (>= 0.11.0)
       multi_json (>= 1.0)
     webmock (1.18.0)
@@ -44,7 +40,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  rake
-  rspec (>= 2.14.1)
+  rake (~> 11.0)
+  rspec (~> 2.0)
   sift-partner!
-  webmock (>= 1.16.0)
+  webmock (~> 1.0)
+
+BUNDLED WITH
+   1.12.5

--- a/lib/sift-partner/client.rb
+++ b/lib/sift-partner/client.rb
@@ -99,7 +99,11 @@ module SiftPartner
       end
 
       def safe_json(http_response)
-        response = Sift::Response.new(http_response.body, http_response.code)
+        response = Sift::Response.new(
+          http_response.body,
+          http_response.code,
+          http_response.response
+        )
         if !response.nil? and response.ok?
           response.json
         else

--- a/lib/sift-partner/version.rb
+++ b/lib/sift-partner/version.rb
@@ -1,4 +1,4 @@
 module SiftPartner
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
   API_VERSION = "3"
 end

--- a/sift-partner.gemspec
+++ b/sift-partner.gemspec
@@ -20,13 +20,12 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # Gems that must be intalled for sift to compile and build
-  s.add_development_dependency "rspec", ">=2.14.1"
-  s.add_development_dependency "webmock", ">= 1.16.0"
+  s.add_development_dependency "rspec", "~> 2.0"
+  s.add_development_dependency "webmock", "~>  1.0"
+  s.add_development_dependency("rake", "~> 11.0")
 
   # Gems that must be intalled for sift to work
-  s.add_dependency "httparty", ">= 0.13.1"
-  s.add_dependency "multi_json", ">= 1.0"
-  s.add_dependency "sift", ">= 1.1.6.2"
-
-  s.add_development_dependency("rake")
+  s.add_dependency "httparty", "~> 0.13.1"
+  s.add_dependency "multi_json", "~> 1.0"
+  s.add_dependency "sift", "~> 1.1.7"
 end


### PR DESCRIPTION
**Problem**:
`sift-ruby` `1.1.7`'s Response initialize method signature was changed. The gemspec for this gem was requiring `>= 1.1.6` so when `1.1.7` was release it broke this gem.

**Solution**:
I've bump the base requirements for this gem, but we have to be more cautious about changing method signatures and versioning semantics. Also updated development gem versions.

cc: @abeppu 